### PR TITLE
[Issue #34]Added Calcite CSS file to head

### DIFF
--- a/head.html
+++ b/head.html
@@ -3,3 +3,4 @@
 <script src="/scripts/scripts.js" type="module"></script>
 <script rel="preload" as="script" src="https://js.arcgis.com/calcite-components/1.8.0/calcite.esm.js" type="module"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>
+<link rel="stylesheet preload" as="style" href="https://js.arcgis.com/calcite-components/1.8.0/calcite.css" type="text/css" crossorigin />


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<34>

Calcite color themes can be implemented and also calcite color variables can be used with addition of this CDN file.

Test URLs:

Original: https://www.esri.com/en-us/about/about-esri/overview
Before: https://main--esri--aemsites.hlx.live/en-us/about/about-esri/overview
After: https://calcite-css--esri--aemsites.hlx.live/en-us/about/about-esri/overview
