### PR TITLE
#25-Implement "Call-To-Action" Block

### DIFF
--- a/blocks/call-to-action/call-to-action.css
+++ b/blocks/call-to-action/call-to-action.css
@@ -46,7 +46,7 @@ p.button-container .button {
   margin-block-start: 0;
 }
 
-@media (min-width: 1px) and (max-width: 768px) {
+@media screen and (max-width: 768px) {
   .call-to-action > div {
     align-items: center;
     flex-direction: column;

--- a/blocks/call-to-action/call-to-action.css
+++ b/blocks/call-to-action/call-to-action.css
@@ -1,0 +1,66 @@
+.call-to-action-wrapper {
+  display: flex;
+  color: var(--calcite-ui-text-1);
+  padding: var(--space-24) 0 var(--space-32);
+  background: var(--calcite-ui-foreground-1);
+  justify-content: center;
+}
+
+.call-to-action {
+  display: flex;
+  inline-size: 99%;
+  position: relative;
+}
+
+.call-to-action > div {
+  display: flex;
+  inline-size: 100%;
+}
+
+.call-to-action > div::after {
+  content: "";
+  block-size: 100%;
+  position: absolute;
+  inline-size: 0.01rem;
+  inset-inline-start: 50%;
+  transform: translateX(-50%);
+  background-color: var(--calcite-ui-border-1);
+}
+
+.call-to-action > div > div {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  block-size: var(--space-56);
+}
+
+.call-to-action h2 {
+  font-size: var(--font-3);
+  font-weight: var(--calcite-font-weight-normal);
+}
+
+p.button-container .button {
+  margin-inline-end: 0;
+  margin-block-start: 0;
+}
+
+@media (max-width: 768px) {
+  .call-to-action > div {
+    align-items: center;
+    flex-direction: column;
+  }
+
+  .call-to-action > div::after {
+      block-size: 0.01rem;
+      inline-size: 100%;
+      inset-inline-start: 0;
+      inset-block-start: 50%;
+      transform: translateY(-50%);
+  }
+
+  .call-to-action > div > div {
+      margin-block: var(--space-10);
+  }
+}

--- a/blocks/call-to-action/call-to-action.css
+++ b/blocks/call-to-action/call-to-action.css
@@ -46,7 +46,7 @@ p.button-container .button {
   margin-block-start: 0;
 }
 
-@media (max-width: 768px) {
+@media (min-width: 1px) and (max-width: 768px) {
   .call-to-action > div {
     align-items: center;
     flex-direction: column;

--- a/blocks/call-to-action/call-to-action.css
+++ b/blocks/call-to-action/call-to-action.css
@@ -46,7 +46,7 @@ p.button-container .button {
   margin-block-start: 0;
 }
 
-@media screen and (max-width: 768px) {
+@media (width <= 768px) {
   .call-to-action > div {
     align-items: center;
     flex-direction: column;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #25 
- Implement "call to action" block styling
- Leveraged calcite variables, spacing, font size, colors
- Pending: Calcite Buttons

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri--aemsites.hlx.live/en-us/about/about-esri/overview
- After: https://call-to-action--esri--aemsites.hlx.live/en-us/about/about-esri/overview
