### PR TITLE
Query index for local navigation

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,0 +1,18 @@
+indices:
+  default:
+    include:
+      - /**
+    exclude:
+      - '/drafts/**'
+      - '/tools/**'
+    target: /query-index.json
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: attribute(el, "content")
+      lastModified:
+        select: none
+        value: parseTimestamp(headers["last-modified"])
+      hasLocalNavigation:
+        selectFirst: main > div > div.local-navigation
+        value: attribute(el, "className")


### PR DESCRIPTION
First step for #75 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri--aemsites.hlx.live/en-us/about/about-esri/overview
- After: https://queryindexlocalnav--esri--aemsites.hlx.live/en-us/about/about-esri/overview
