### PR TITLE
Avoid rel=preload for calcite elements to prevent blocking

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,6 +1,4 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <script src="/scripts/aem.js" type="module"></script>
 <script src="/scripts/scripts.js" type="module"></script>
-<script rel="preload" as="script" src="https://js.arcgis.com/calcite-components/1.8.0/calcite.esm.js" type="module"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>
-<link rel="stylesheet preload" as="style" href="https://js.arcgis.com/calcite-components/1.8.0/calcite.css" type="text/css" crossorigin />

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -10,6 +10,7 @@ import {
   waitForLCP,
   loadBlocks,
   loadCSS,
+  loadScript,
 } from './aem.js';
 
 import { div, iframe, domEl } from './dom-helpers.js';
@@ -141,6 +142,9 @@ export function decorateMain(main) {
  * @param {Element} doc The container element
  */
 async function loadEager(doc) {
+  loadScript('https://js.arcgis.com/calcite-components/1.8.0/calcite.esm.js');
+  loadCSS('https://js.arcgis.com/calcite-components/1.8.0/calcite.css');
+
   document.documentElement.lang = 'en';
   decorateTemplateAndTheme();
   const main = doc.querySelector('main');


### PR DESCRIPTION
Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri--aemsites.hlx.live/en-us/about/about-esri/overview
- After: https://fix-lighthousescore--esri--aemsites.hlx.page/en-us/about/about-esri/overview
- After: https://fix-lighthousescore--esri--aemsites.hlx.live/en-us/about/about-esri/overview
