### PR TITLE
Add calcite-mode-light and calcite-mode-dark on "light" and "dark" themes

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -6,7 +6,7 @@ import {
   decorateIcons,
   decorateSections,
   decorateBlocks,
-  decorateTemplateAndTheme,
+  decorateTemplateAndTheme as aemDecorateTemplateAndTheme,
   waitForLCP,
   loadBlocks,
   loadCSS,
@@ -135,6 +135,16 @@ export function decorateMain(main) {
   decorateSections(main);
   decorateBlocks(main);
   decorateVideoLinks(main);
+}
+
+function decorateTemplateAndTheme() {
+  aemDecorateTemplateAndTheme();
+  const { classList } = document.body;
+  if (classList.contains('light')) {
+    classList.add('calcite-mode-light');
+  } else if (classList.contains('dark')) {
+    classList.add('calcite-mode-dark');
+  }
 }
 
 /**


### PR DESCRIPTION
Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri--aemsites.hlx.live/drafts/acarol/overview
- After: https://simplifiedcalcitethemes--esri--aemsites.hlx.live/drafts/acarol/overview
