### PR TITLE
Load calcite button as "module"

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -142,7 +142,7 @@ export function decorateMain(main) {
  * @param {Element} doc The container element
  */
 async function loadEager(doc) {
-  loadScript('https://js.arcgis.com/calcite-components/1.8.0/calcite.esm.js');
+  loadScript('https://js.arcgis.com/calcite-components/1.8.0/calcite.esm.js', { type: 'module' });
   loadCSS('https://js.arcgis.com/calcite-components/1.8.0/calcite.css');
 
   document.documentElement.lang = 'en';


### PR DESCRIPTION
Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri--aemsites.hlx.live/en-us/about/about-esri/overview
- After: https://fix-calciteload--esri--aemsites.hlx.live/en-us/about/about-esri/overview
