### PR TITLE
#99-CardsPerRow

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -80,6 +80,7 @@
 /* Cards per row - width calculation */
 .cardsperrow > ul > li {
   --cards-per-row: 1;
+  
   inline-size: calc(100% / var(--cards-per-row));
 
   @media (width >= 768px) {

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -77,16 +77,50 @@
   }
 }
 
+/* Cards per row - width calculation */
+.cardsperrow > ul > li {
+  --cards-per-row: 1;
+  inline-size: calc(100% / var(--cards-per-row));
+
+  @media (width >= 768px) {
+    --cards-per-row: 2;
+  }
+
+  @media (width >= 1024px) {
+    --cards-per-row: 3;
+  }
+}
+
+@media (width >= 1440px) {
+  .cardsperrow-1 > ul > li {
+    --cards-per-row: 1;
+  }
+  
+  .cardsperrow-2 > ul > li {
+    --cards-per-row: 2;
+  }
+  
+  .cardsperrow-3 > ul > li {
+    --cards-per-row: 3;
+  }
+  
+  .cardsperrow-4 > ul > li{
+    --cards-per-row: 4;
+  }
+  
+  .cardsperrow-5 > ul > li {
+    --cards-per-row: 5;
+  }
+  
+  .cardsperrow-6 > ul > li {
+    --cards-per-row: 6;
+  }
+}
+
 /* Cards Simple */
 .cards.simple li{
   position: relative;
   display: flex;
-}
-
-@media (width >= 1440px) {
-  .cards.simple li {
-    inline-size: 33.3334%;
-  }
 }
 
 .cards.simple .cards-card-body{

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -4,7 +4,7 @@ import { domEl } from '../../scripts/dom-helpers.js';
 export default function decorate(block) {
   block.classList.add('calcite-mode-dark');
 
-  const processSimpleCard = function (div) {
+  const processSimpleCard = (div) => {
     if (!block.classList.contains('simple')) {
       return;
     }

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -8,6 +8,7 @@ export default function decorate(block) {
     if (!block.classList.contains('simple')) {
       return;
     }
+    block.classList.add('cardsperrow');
     const anchorEl = div.querySelector('a');
     const cardBodyContent = domEl('div', { class: 'card-body-content' });
     if (anchorEl) {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Notes:
For 'Card Simple' variation, authors should be able to choose the number of cards in a row. As per current AEM site,
Card Simple and Standard -> 1-6 per row
Card Editorial -> 1-2 per row
With these changes, authors can give 'Cards (simple, cardsPerRow-*)' to define the number of cards displayed per row.

Fix #99 

Test URLs:
Original: https://www.esri.com/en-us/digital-twin/overview
Before: https://main--esri--aemsites.hlx.live/drafts/shared/cards-simple
After: https://cardsperrow--esri--aemsites.hlx.live/drafts/shared/cards-simple
