### PR TITLE
#95-Cardstandard Variation

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -1,6 +1,9 @@
 .cards-card-body {
   --content-spacing: var(--space-2);
   --content-end-spacing: var(--space-5);
+  --subtitle-size: var(--font-minus-1);
+  --description-size: var(--font-minus-1);
+  --category-size: var(--font-minus-2);
 }
 
 .cards {
@@ -143,11 +146,6 @@
 
   p{
     margin: 0;
-
-    &:last-child {
-      padding: 0;
-      margin-block-end: var(--content-end-spacing);
-    }
   }
 
   h3{
@@ -176,10 +174,120 @@
   }
 }
 
-.cards.simple .cards-card-body:is(:focus-within, :hover){
+.cards.simple a:is(:hover, :focus, :active) {
+  border-inline-start: 3px solid var(--calcite-ui-brand);
+}
+
+/* Cards Standard */
+.cards.standard li{
+  position: relative;
+  display: flex;
+}
+
+.cards.standard .cards-card-body{
+  background-color: var(--calcite-ui-foreground-1);
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  word-wrap: break-word;
+  transition: border-color 0.25s linear;
+  border: 1px solid var(--calcite-ui-border-1);
+
+  &:is(:hover,:focus-within) {
+    border: 1px solid var(--calcite-ui-brand);
+  }
+  
+  .card-body-content {
+    margin: 0;
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    padding-block-end: var(--space-5);
+    position: relative;
+  }
+
+  p {
+    margin: 0;
+    color: var(--calcite-ui-text-1);
+    font-size: var(--description-size);
+
+    &:has(> picture) {
+      position: relative;
+    }
+
+    &:last-child {
+      padding: 0;
+      margin-block-end: var(--content-end-spacing);
+    }
+
+    &.overlay-text {
+      padding: var(--space-2) var(--space-5);
+      width: 100%;
+      letter-spacing: .2rem;
+      background-color: var(--esri-ui-opacity85-inverse);
+      margin-block-end: 0;
+      font-weight: var(--calcite-font-weight-bold);
+      text-transform: uppercase;
+      color: var(--calcite-ui-text-2);
+      font-size: var(--category-size);
+      position: absolute;
+      box-sizing: border-box;
+      bottom: 21px;
+    }
+  }
+
+  h3,h4,p:last-child {
+    margin:0;
+    padding-inline: var(--space-5);
+  }
+
+  h3 {
+    margin-bottom: var(--space-3);
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-align: start;
+  }
+
+  h4 {
+    color: var(--calcite-ui-text-2);
+    margin-block-end: var(--content-spacing);
+    font-size: var(--subtitle-size);
+  }
+
+  a {
+    color: var(--calcite-ui-text-1);
+    display: flex;
+    flex: 1;
+    white-space: normal;
+    text-align: start;
+    padding: 0;
+    background-color: transparent;
+    transition: border-color 0.25s linear;
+    line-height: 1.5;
+    margin: 0;
+    text-decoration: none;
+  }
+
+  picture {
+    position: relative;
+
+    img {
+      padding-block-end: var(--space-4);
+    }
+  }
+}
+
+.cards.simple .cards-card-body:is(:hover,:focus-within){
   border: 1px solid var(--calcite-ui-brand);
 }
 
-.cards.simple a:is(:hover, :focus, :active) {
-  border-inline-start: 3px solid var(--calcite-ui-brand);
+.cards.simple .cards-card-body p:last-child {
+  padding: 0;
+  margin-block-end: var(--content-end-spacing);
+}
+
+.cards.standard .cards-card-body:not(:has(a)):is(:hover,:focus-within) {
+  border: 1px solid var(--calcite-ui-border-1);
 }

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -275,8 +275,8 @@
 
     img {
       padding-block-end: var(--space-4);
-      width: 100%;
-      height: auto;
+      inline-size: 100%;
+      block-size: auto;
     }
   }
 }

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -275,6 +275,8 @@
 
     img {
       padding-block-end: var(--space-4);
+      width: 100%;
+      height: auto;
     }
   }
 }

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -222,7 +222,7 @@
 
     &.overlay-text {
       padding: var(--space-2) var(--space-5);
-      width: 100%;
+      inline-size: 100%;
       letter-spacing: .2rem;
       background-color: var(--esri-ui-opacity85-inverse);
       margin-block-end: 0;
@@ -232,7 +232,7 @@
       font-size: var(--category-size);
       position: absolute;
       box-sizing: border-box;
-      bottom: 21px;
+      inset-block-end: 21px;
     }
   }
 
@@ -242,7 +242,7 @@
   }
 
   h3 {
-    margin-bottom: var(--space-3);
+    margin-block-end: var(--space-3);
     display: -webkit-box;
     -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -272,6 +272,8 @@
 
   picture {
     position: relative;
+    inline-size: 100%;
+    block-size: auto;
 
     img {
       padding-block-end: var(--space-4);

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -23,6 +23,31 @@ export default function decorate(block) {
     });
   };
 
+  const processStandardCard = (div) => {
+    if (!block.classList.contains('standard')) {
+      return;
+    }
+    block.classList.add('cardsperrow');
+    const anchorEl = div.querySelector('a');
+    const cardBodyContent = domEl('div', { class: 'card-body-content' });
+    if (anchorEl) {
+      anchorEl.replaceChildren(cardBodyContent);
+      div.append(anchorEl);
+    } else {
+      div.append(cardBodyContent);
+    }
+    div.querySelectorAll('p').forEach((p) => { if (p.textContent === '') p.remove(); });
+    [...div.querySelectorAll('.cards-card-body > :not(.card-body-content, a)')].forEach((el) => {
+      cardBodyContent.append(el);
+      if (el.tagName === 'P' && el.children.length === 0 && el.parentNode.firstElementChild === el) {
+        el.classList.add('overlay-text');
+      }
+    });
+    const pictureEl = div.querySelector('picture').closest('p');
+    const overlayTextEl = div.querySelector('.overlay-text');
+    if (overlayTextEl) pictureEl.append(overlayTextEl);
+  };
+
   /* change to ul, li */
   const ul = document.createElement('ul');
   [...block.children].forEach((row) => {
@@ -32,6 +57,7 @@ export default function decorate(block) {
       if (div.children.length === 1 && div.querySelector('picture')) div.className = 'cards-card-image';
       else { div.className = 'cards-card-body'; }
       processSimpleCard(div);
+      processStandardCard(div);
     });
     ul.append(li);
   });

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -33,6 +33,27 @@
 
   -webkit-font-smoothing: antialiased;
 
+  .calcite-mode-dark {
+    --esri-ui-opacity00: rgb(255 255 255/ 0%);
+    --esri-ui-opacity20: rgb(255 255 255/ 20%);
+    --esri-ui-opacity40: rgb(255 255 255/ 40%);
+    --esri-ui-opacity50: rgb(255 255 255/ 50%);
+    --esri-ui-opacity80: rgb(255 255 255/ 80%);
+    --esri-ui-opacity85: rgb(255 255 255/ 85%);
+    --esri-ui-opacity90: rgb(255 255 255/ 90%);
+    --esri-ui-opacity95: rgb(255 255 255/ 95%);
+    --esri-ui-opacity97: rgb(255 255 255/ 97%);
+    --esri-ui-opacity00-inverse: rgb(53 53 53 / 0%);
+    --esri-ui-opacity20-inverse: rgb(53 53 53 / 2%);
+    --esri-ui-opacity40-inverse: rgb(53 53 53 / 4%);
+    --esri-ui-opacity50-inverse: rgb(53 53 53 / 5%);
+    --esri-ui-opacity80-inverse: rgb(53 53 53 / 80%);
+    --esri-ui-opacity85-inverse: rgb(53 53 53 / 85%);
+    --esri-ui-opacity90-inverse: rgb(53 53 53 / 90%);
+    --esri-ui-opacity95-inverse: rgb(53 53 53 / 95%);
+    --esri-ui-opacity97-inverse: rgb(53 53 53 / 97%);
+  }
+
   /* fonts */
   --calcite-code-family: "Consolas", "Andale Mono", "Lucida Console", "Monaco", monospace;
   --calcite-sans-family: "Avenir Next", "Avenir", "Helvetica Neue", sans-serif;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #95 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri--aemsites.hlx.live/en-us/about/about-esri/americas
- After: https://cardstandard--esri--aemsites.hlx.live/drafts/shared/cards-standard

**Notes:**
- Had to update the sharepoint doc/page.
- Updated how the component is authored because the import of page is generating all 'p' tags and it is not possible to differentiate them as we have title, subtitle, description and overlay text in this usecase and they are not mandatory fields so there can be multiple combinations.
- Updated title to be authored as H3, subtitle to be authored as H4, overlay text and description to be 'p' tags.
