### PR TITLE
Move alternate lang to header and fix lint issues

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -63,9 +63,8 @@ async function alternateHeaders() {
  * @param {Element} block The header block element
  */
 export default async function decorate() {
-  alternateHeaders().then(() => {
+  await alternateHeaders().then(async () => {
     window.gnav_jsonPath = '/2022-nav-config.25.json';
-    loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js');
+    await Promise.all([loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js'), loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css')]);
   });
-  loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css');
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,11 +1,71 @@
 import { loadCSS, loadScript } from '../../scripts/aem.js';
+import ffetch from '../../scripts/ffetch.js';
+import { link } from '../../scripts/dom-helpers.js';
+
+/**
+ * get all entries from the index
+ * create alternate langauge links for each entry
+ */
+async function alternateHeaders() {
+  // get current page url, parse and remove the protocol and domain
+  const url = window.location.href;
+  const origin = '/en-us';
+  const path = url.replace(window.location.origin, '');
+  // parse path to remove the /xx-xx/ from the beginning
+  const pathArray = path.split('/');
+  const pathArrayLength = pathArray.length;
+  let pathArrayString = '';
+
+  for (let i = 0; i < pathArrayLength; i += 1) {
+    if (i !== 1 || !/^[a-z]{2}-[a-z]{2}$/.test(pathArray[i])) {
+      if (pathArray[i] !== '') {
+        pathArrayString += `/${pathArray[i]}`;
+      }
+    }
+  }
+
+  const entries = await ffetch('/query-index.json')
+    .all();
+
+  const head = document.querySelector('head');
+  entries
+    .map((entry) => {
+      if (entry.path.includes(pathArrayString)) {
+        const match = entry.path.match(/^\/([a-z]{2}-[a-z]{2})\//);
+        if (match) {
+          return [entry, match[1]];
+        }
+      }
+
+      return null;
+    })
+    .filter((entry) => entry !== null)
+    .forEach(([entry, hreflang]) => {
+      // <link rel="alternate" hreflang="en" href="https://www.example.com/en/page.html" />
+      // create alternate links for all matching entries
+      head.appendChild(link({
+        rel: 'alternate',
+        hreflang,
+        href: window.location.origin + entry.path,
+      }));
+    });
+
+  // add x-default alternate link
+  const xDefaultLink = document.createElement('link');
+  xDefaultLink.rel = 'alternate';
+  xDefaultLink.hreflang = 'x-default';
+  xDefaultLink.setAttribute('href', window.location.origin + origin + pathArrayString);
+  head.appendChild(xDefaultLink);
+}
 
 /**
  * loads and decorates the header, mainly the nav
  * @param {Element} block The header block element
  */
 export default async function decorate() {
-  window.gnav_jsonPath = '/2022-nav-config.25.json';
-  loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js');
+  alternateHeaders().then(() => {
+    window.gnav_jsonPath = '/2022-nav-config.25.json';
+    loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js');
+  });
   loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css');
 }

--- a/scripts/dom-helpers.js
+++ b/scripts/dom-helpers.js
@@ -86,6 +86,9 @@ export function p(...items) {
 export function a(...items) {
   return domEl('a', ...items);
 }
+export function link(...items) {
+  return domEl('link', ...items);
+}
 export function h1(...items) {
   return domEl('h1', ...items);
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -14,9 +14,8 @@ import {
 } from './aem.js';
 
 import { div, iframe, domEl } from './dom-helpers.js';
-import ffetch from './ffetch.js';
 
-const LCP_BLOCKS = []; // add your LCP blocks to the list
+const LCP_BLOCKS = ['header']; // add your LCP blocks to the list
 
 /**
  * Builds hero block and prepends to main in a new section.
@@ -46,66 +45,9 @@ async function loadFonts() {
 }
 
 /**
- * get all entries from the index
- * create alternate langauge links for each entry
- */
-// get current page url, parse and remove the protocol and domain
-const url = window.location.href;
-const origin = '/en-us';
-const path = url.replace(window.location.origin, '');
-// parse path to remove the /xx-xx/ from the beginning
-const pathArray = path.split('/');
-const pathArrayLength = pathArray.length;
-let pathArrayString = '';
-let splitPattern = '';
-
-for (let i = 0; i < pathArrayLength; i++) {
-  if (i === 1 && /^[a-z]{2}-[a-z]{2}$/.test(pathArray[i])) {
-    splitPattern = pathArray[i]; // save the /xx-xx/ pattern
-    continue;
-  }
-  if (pathArray[i] !== '') {
-    pathArrayString += '/' + pathArray[i];
-  }
-}
-
-const entries = ffetch('/query-index.json');
-const matchingEntries = [];
-const hreflangArray = [];
-
-for await (const entry of entries) {
-  if (entry.path.includes(pathArrayString)) {
-    matchingEntries.push(entry);
-    const match = entry.path.match(/^\/([a-z]{2}-[a-z]{2})\//);
-    if (match) {
-      hreflangArray.push(match[1]);
-    }
-  }
-}
-
-// <link rel="alternate" hreflang="en" href="https://www.example.com/en/page.html" />
-// using the hreflangArray and matchingEntries arrays,
-// create alternate links for all entries in arrays
-const head = document.querySelector('head');
-for (let i = 0; i < hreflangArray.length; i++) {
-  const link = document.createElement('link');
-  link.rel = 'alternate';
-  link.hreflang = hreflangArray[i];
-  link.href = window.location.origin + matchingEntries[i].path;
-  head.appendChild(link);
-}
-// add x-default alternate link
-const xDefaultLink = document.createElement('link');
-xDefaultLink.rel = 'alternate';
-xDefaultLink.hreflang = 'x-default';
-xDefaultLink.setAttribute('href', window.location.origin + origin + pathArrayString);
-head.appendChild(xDefaultLink);
-
-/**
  * Opens an iframe with the video when clicking on anchor tags.
  * @param {Element} element container element
  */
-
 function decorateVideoLinks(element) {
   const anchors = element.querySelectorAll('a');
   anchors.forEach((a) => {


### PR DESCRIPTION
Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri--aemsites.hlx.live/
- After: https://lang-in-header--esri--aemsites.hlx.live/
