### PR TITLE
chore: fix block parameters reverse position

### DIFF
--- a/blocks/map/map.js
+++ b/blocks/map/map.js
@@ -33,11 +33,11 @@ const getMapFrame = (url) => {
   return mapFrame;
 };
 
-export default async function decorate(block) {
+export default function decorate(block) {
   const blockParams = block.querySelectorAll('p');
 
-  const mapLink = blockParams[0].innerText;
-  const textParameter = blockParams[1].innerText;
+  const textParameter = blockParams[0].innerText;
+  const mapLink = blockParams[1].innerText;
   block.textContent = '';
 
   const gridContainer = div({ class: 'grid-container' });


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/americas
- Before: https://main--esri--aemsites.hlx.live/en-us/about/about-esri/americas
- After: https://reverse-block-params--esri--aemsites.hlx.live/en-us/about/about-esri/americas