### PR TITLE
chore: remove no descending specificity rule.

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,14 +3,15 @@
   "plugins": ["stylelint-use-logical"],
   "rules": {
     "custom-property-pattern": null,
+    "keyframes-name-pattern": null,
     "no-empty-source": null,
+    "no-descending-specificity": null,
     "declaration-no-important": true,
     "max-nesting-depth": [3,
       {
         "message": "Please keep the nesting depth 3 or less."
       }
     ],
-    "keyframes-name-pattern": null,
     "csstools/use-logical": ["always", {"except": ["float", "inset-block"]}]
   }
 }


### PR DESCRIPTION
Disabled the specificity rule as it was intrusive and non-consistent. 
Reorder rules 

Fix #128 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri--aemsites.aem.live/
- After: https://sl-update--esri--aemsites.aem.live/
