### PR TITLE
Implement columns calcite-mode-gray and add calcite-mode-* to every block with light/dark/gray variants

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -19,6 +19,10 @@
   display: block;
 }
 
+.columns.calcite-mode-gray {
+  background-color: var(--calcite-ui-foreground-2);
+}
+
 @media (width >= 900px) {
   .columns > div {
     align-items: center;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -127,6 +127,24 @@ function buildAutoBlocks(main) {
   }
 }
 
+function decorateMode(element) {
+  const { classList } = element;
+  const calciteModes = ['light', 'dark', 'gray'];
+  calciteModes.forEach((mode) => {
+    if (classList.contains(mode)) {
+      classList.add(`calcite-mode-${mode}`);
+    }
+  });
+}
+
+export function decorateBlockMode(block) {
+  decorateMode(block);
+}
+
+function decorateModes(main) {
+  main.querySelectorAll('.block').forEach(decorateMode);
+}
+
 /**
  * Decorates the main element.
  * @param {Element} main The main element
@@ -139,21 +157,10 @@ export function decorateMain(main) {
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
+  decorateModes(main);
   decorateVideoLinks(main);
 }
 
-function decorateMode(element) {
-  const { classList } = element;
-  if (classList.contains('light')) {
-    classList.add('calcite-mode-light');
-  } else if (classList.contains('dark')) {
-    classList.add('calcite-mode-dark');
-  }
-}
-
-export function decorateBlockMode(block) {
-  decorateMode(block);
-}
 export function decorateTemplateAndTheme() {
   aemDecorateTemplateAndTheme();
   decorateMode(document.body);


### PR DESCRIPTION
Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/europe/overview
- Before: https://main--esri--aemsites.hlx.live/en-us/about/about-esri/europe/overview
![image](https://github.com/user-attachments/assets/9dc209af-a124-4ccf-a0ed-a6255103d702)

- After: https://feature-calcitemodesforblocks--esri--aemsites.hlx.live/en-us/about/about-esri/europe/overview
![image](https://github.com/user-attachments/assets/dd8d7036-6193-49d5-977f-94aecee89702)


