### PR TITLE
feat: update html lang and dir

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -81,5 +81,5 @@ export default async function decorate() {
   await alternateHeaders().then(async () => {
     window.gnav_jsonPath = '/2022-nav-config.25.json';
     await Promise.all([loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js'), loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css')]);
-  }); 
+  });
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -31,7 +31,7 @@ async function alternateHeaders() {
   let dir = 'ltr';
   if (pathArray[1] && (pathArray[1] === 'ar-sa' || pathArray[1] === 'he-il' || pathArray[1] === 'ar-kw')) { dir = 'rtl'; }
   document.querySelector('html').setAttribute('dir', dir);
-  
+
   const lang = (pathArray[1] === 'en-us') ? 'en' : (pathArray[1] || 'en');
   document.querySelector('html').setAttribute('lang', lang);
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,6 +1,22 @@
-import { loadCSS, loadScript } from '../../scripts/aem.js';
+import { loadCSS, loadScript, getMetadata } from '../../scripts/aem.js';
 import ffetch from '../../scripts/ffetch.js';
 import { link } from '../../scripts/dom-helpers.js';
+
+/**
+  * Use getMetadata to get the locale of the page
+  * * Update the html lang attribute to the locale
+  * If the language is Arabic, Hebrew or Kuwaiti Arabic, set the direction to rtl
+  */
+async function setLocaleAndDirection() {
+  const locale = getMetadata('og:locale') || 'en-us';
+  const dir = (locale === 'ar-sa' || locale === 'he-il' || locale === 'ar-kw') ? 'rtl' : 'ltr';
+  document.querySelector('html').setAttribute('dir', dir);
+
+  const lang = (locale === 'en-us') ? 'en' : locale;
+  document.querySelector('html').setAttribute('lang', lang);
+}
+
+await setLocaleAndDirection();
 
 /**
  * get all entries from the index
@@ -23,17 +39,6 @@ async function alternateHeaders() {
       }
     }
   }
-
-  /**
-  * Use pathArray to determine the direction of the language
-  * If the language is Arabic, Hebrew or Kuwaiti Arabic, set the direction to rtl
-  */
-  let dir = 'ltr';
-  if (pathArray[1] && (pathArray[1] === 'ar-sa' || pathArray[1] === 'he-il' || pathArray[1] === 'ar-kw')) { dir = 'rtl'; }
-  document.querySelector('html').setAttribute('dir', dir);
-
-  const lang = (pathArray[1] === 'en-us') ? 'en' : (pathArray[1] || 'en');
-  document.querySelector('html').setAttribute('lang', lang);
 
   const entries = await ffetch('/query-index.json')
     .all();

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -78,8 +78,10 @@ async function alternateHeaders() {
  */
 export default async function decorate() {
   setLocaleAndDirection();
-  await alternateHeaders().then(async () => {
-    window.gnav_jsonPath = '/2022-nav-config.25.json';
-    await Promise.all([loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js'), loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css')]);
-  });
+  window.gnav_jsonPath = '/2022-nav-config.25.json';
+  await Promise.all([
+    alternateHeaders(),
+    loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js'),
+    loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css')
+  ]);
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -82,6 +82,6 @@ export default async function decorate() {
   await Promise.all([
     alternateHeaders(),
     loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js'),
-    loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css')
+    loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css'),
   ]);
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -77,9 +77,9 @@ async function alternateHeaders() {
  * @param {Element} block The header block element
  */
 export default async function decorate() {
+  setLocaleAndDirection();
   await alternateHeaders().then(async () => {
     window.gnav_jsonPath = '/2022-nav-config.25.json';
     await Promise.all([loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js'), loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css')]);
-  });
-  setLocaleAndDirection();
+  }); 
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -24,6 +24,17 @@ async function alternateHeaders() {
     }
   }
 
+   /**
+   * Use pathArray to determine the direction of the language
+   * If the language is Arabic, Hebrew or Kuwaiti Arabic, set the direction to rtl
+  */
+   let dir = 'ltr';
+   if (pathArray[1] && (pathArray[1] === 'ar-sa' || pathArray[1] === 'he-il' || pathArray[1] === 'ar-kw')) { dir = 'rtl'; }
+   document.querySelector('html').setAttribute('dir', dir);
+   
+   const lang = (pathArray[1] === 'en-us') ? 'en' : (pathArray[1] || 'en');
+   document.querySelector('html').setAttribute('lang', lang);
+
   const entries = await ffetch('/query-index.json')
     .all();
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -78,10 +78,8 @@ async function alternateHeaders() {
  */
 export default async function decorate() {
   setLocaleAndDirection();
-  window.gnav_jsonPath = '/2022-nav-config.25.json';
-  await Promise.all([
-    alternateHeaders(),
-    loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js'),
-    loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css'),
-  ]);
+  await alternateHeaders().then(async () => {
+    window.gnav_jsonPath = '/2022-nav-config.25.json';
+    await Promise.all([loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js'), loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css')]);
+  });
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -31,7 +31,7 @@ async function alternateHeaders() {
   let dir = 'ltr';
   if (pathArray[1] && (pathArray[1] === 'ar-sa' || pathArray[1] === 'he-il' || pathArray[1] === 'ar-kw')) { dir = 'rtl'; }
   document.querySelector('html').setAttribute('dir', dir);
-   
+  
   const lang = (pathArray[1] === 'en-us') ? 'en' : (pathArray[1] || 'en');
   document.querySelector('html').setAttribute('lang', lang);
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -7,7 +7,7 @@ import { link } from '../../scripts/dom-helpers.js';
   * * Update the html lang attribute to the locale
   * If the language is Arabic, Hebrew or Kuwaiti Arabic, set the direction to rtl
   */
-async function setLocaleAndDirection() {
+function setLocaleAndDirection() {
   const locale = getMetadata('og:locale') || 'en-us';
   const dir = (locale === 'ar-sa' || locale === 'he-il' || locale === 'ar-kw') ? 'rtl' : 'ltr';
   document.querySelector('html').setAttribute('dir', dir);
@@ -15,8 +15,6 @@ async function setLocaleAndDirection() {
   const lang = (locale === 'en-us') ? 'en' : locale;
   document.querySelector('html').setAttribute('lang', lang);
 }
-
-await setLocaleAndDirection();
 
 /**
  * get all entries from the index
@@ -83,4 +81,5 @@ export default async function decorate() {
     window.gnav_jsonPath = '/2022-nav-config.25.json';
     await Promise.all([loadScript('https://webapps-cdn.esri.com/CDN/components/global-nav/js/gn.js'), loadCSS('https://webapps-cdn.esri.com/CDN/components/global-nav/css/gn.css')]);
   });
+  setLocaleAndDirection();
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -24,16 +24,16 @@ async function alternateHeaders() {
     }
   }
 
-   /**
-   * Use pathArray to determine the direction of the language
-   * If the language is Arabic, Hebrew or Kuwaiti Arabic, set the direction to rtl
+  /**
+  * Use pathArray to determine the direction of the language
+  * If the language is Arabic, Hebrew or Kuwaiti Arabic, set the direction to rtl
   */
-   let dir = 'ltr';
-   if (pathArray[1] && (pathArray[1] === 'ar-sa' || pathArray[1] === 'he-il' || pathArray[1] === 'ar-kw')) { dir = 'rtl'; }
-   document.querySelector('html').setAttribute('dir', dir);
+  let dir = 'ltr';
+  if (pathArray[1] && (pathArray[1] === 'ar-sa' || pathArray[1] === 'he-il' || pathArray[1] === 'ar-kw')) { dir = 'rtl'; }
+  document.querySelector('html').setAttribute('dir', dir);
    
-   const lang = (pathArray[1] === 'en-us') ? 'en' : (pathArray[1] || 'en');
-   document.querySelector('html').setAttribute('lang', lang);
+  const lang = (pathArray[1] === 'en-us') ? 'en' : (pathArray[1] || 'en');
+  document.querySelector('html').setAttribute('lang', lang);
 
   const entries = await ffetch('/query-index.json')
     .all();


### PR DESCRIPTION
Update `lang` in `html` and update `dir=[ltr | rtl]` based on language. 

Fix #153 

Test URLs:
- Original: https://www.esri.com/en-us/about/about-esri/overview
- Before: https://main--esri--aemsites.hlx.live/
- After: https://lang-dir--esri--aemsites.hlx.live/
